### PR TITLE
Support web fallback

### DIFF
--- a/typescript/native-auth/react-nextjs-sample/proxy.config.js
+++ b/typescript/native-auth/react-nextjs-sample/proxy.config.js
@@ -3,8 +3,8 @@
  * entryPath: The path to the API on the react app ex. /api
  * proxy: The URL to proxy the requests
  */
-const tenantSubdomain = "Enter_the_Tenant_Subdomain_Here";
-const tenantId = "Enter_the_Tenant_Id_Here";
+const tenantSubdomain = "ciamtestlocal";
+const tenantId = "cd97f2df-f1e9-4ee6-8dc0-d036accad626";
 
 const config = {
     localApiPath: "/api",

--- a/typescript/native-auth/react-nextjs-sample/proxy.config.js
+++ b/typescript/native-auth/react-nextjs-sample/proxy.config.js
@@ -3,8 +3,8 @@
  * entryPath: The path to the API on the react app ex. /api
  * proxy: The URL to proxy the requests
  */
-const tenantSubdomain = "ciamtestlocal";
-const tenantId = "cd97f2df-f1e9-4ee6-8dc0-d036accad626";
+const tenantSubdomain = "Enter_the_Tenant_Subdomain_Here";
+const tenantId = "Enter_the_Tenant_Id_Here";
 
 const config = {
     localApiPath: "/api",

--- a/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
+++ b/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
@@ -38,7 +38,7 @@ export default function SignIn() {
             if (result.error) {
                 if (result.error.isUserNotFound()) {
                     setError("User not found");
-                } else if (result.error.isFallbackRequired()) {
+                } else if (result.error.isRedirectRequired()) {
                     const popUpRequest: PopupRequest = {
                         authority: customAuthConfig.auth.authority,
                         scopes: [],

--- a/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
+++ b/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
@@ -38,7 +38,7 @@ export default function SignIn() {
             if (result.error) {
                 if (result.error.isUserNotFound()) {
                     setError("User not found");
-                } else if (result.error.isRedirectionRequired()) {
+                } else if (result.error.isFallbackRequired()) {
                     const popUpRequest: PopupRequest = {
                         authority: customAuthConfig.auth.authority,
                         scopes: [],

--- a/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
+++ b/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
@@ -41,7 +41,7 @@ export default function SignIn() {
                 } else if (result.error.isRedirectionRequired()) {
                     const popUpRequest: PopupRequest = {
                         authority: customAuthConfig.auth.authority,
-                        scopes: ["openid"],
+                        scopes: [],
                         redirectUri: customAuthConfig.auth.redirectUri || "",
                     }
                     const redirectResult = await app.loginPopup(popUpRequest);

--- a/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
+++ b/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import { CustomAuthPublicClientApplication, SignInCompletedState } from "@azure/msal-custom-auth";
-import { SignInState } from "@azure/msal-custom-auth";
 import { customAuthConfig } from "../../config/auth-config";
 import { styles } from "./styles/styles";
 import { handleError } from "./utils";
@@ -11,6 +10,7 @@ import { PasswordForm } from "./components/PasswordForm";
 import { CodeForm } from "./components/CodeForm";
 import { UserInfo } from "./components/UserInfo";
 import { SignInCodeRequiredState, SignInPasswordRequiredState } from "@azure/msal-custom-auth";
+import { PopupRequest } from "@azure/msal-browser";
 
 export default function SignIn() {
     const [username, setUsername] = useState("");
@@ -38,6 +38,17 @@ export default function SignIn() {
             if (result.error) {
                 if (result.error.isUserNotFound()) {
                     setError("User not found");
+                } else if (result.error.isRedirect()) {
+                    console.log(result)
+                    const popUpRequest: PopupRequest = {
+                        authority: customAuthConfig.auth.authority,
+                        scopes: ["openid"],
+                        redirectUri: customAuthConfig.auth.redirectUri || "",
+                    }
+                    const redirectResult = await app.loginPopup(popUpRequest);
+                    result.state = new SignInCompletedState()
+                    setData(redirectResult.account);
+                    setSignInState(result.state);
                 } else {
                     setError("An error occurred during sign in");
                 }

--- a/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
+++ b/typescript/native-auth/react-nextjs-sample/src/app/sign-in/page.tsx
@@ -38,8 +38,7 @@ export default function SignIn() {
             if (result.error) {
                 if (result.error.isUserNotFound()) {
                     setError("User not found");
-                } else if (result.error.isRedirect()) {
-                    console.log(result)
+                } else if (result.error.isRedirectionRequired()) {
                     const popUpRequest: PopupRequest = {
                         authority: customAuthConfig.auth.authority,
                         scopes: ["openid"],

--- a/typescript/native-auth/react-nextjs-sample/src/config/auth-config.ts
+++ b/typescript/native-auth/react-nextjs-sample/src/config/auth-config.ts
@@ -8,7 +8,7 @@ export const customAuthConfig: CustomAuthConfiguration = {
     auth: {
         clientId: "Enter_the_Application_Id_Here",
         authority: "https://Enter_the_Tenant_Subdomain_Here.ciamlogin.com",
-        redirectUri: "",
+        redirectUri: "/", // You must register this URI on Azure Portal/App Registration. Defaults to window.location.href e.g. http://localhost:3000/
         postLogoutRedirectUri: "",
         navigateToLoginRequestUrl: false,
     },


### PR DESCRIPTION
When challenge type is `redirect` only, user could reuse the built-in popUpLogin from MSAL JS to continue to flow with a pop up interactively.