### PR TITLE
Suppress the CodeQL warnings

### DIFF
--- a/API/React/ReactAuthOTPSimple/cors.js
+++ b/API/React/ReactAuthOTPSimple/cors.js
@@ -8,13 +8,13 @@ http
     const reqUrl = url.parse(req.url);
     const domain = url.parse(proxyConfig.proxy).hostname;
     if (reqUrl.pathname.startsWith(proxyConfig.localApiPath)) {
-      
+
       const targetUrl = proxyConfig.proxy + reqUrl.pathname?.replace(proxyConfig.localApiPath, "") + (reqUrl.search || "");
 
       console.log("Incoming request -> " + req.url + " ===> " + reqUrl.pathname);
 
       const proxyReq = https.request(
-        targetUrl,
+        targetUrl, // CodeQL [SM04580] The newly generated target URL utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
         {
           method: req.method,
           headers: {

--- a/API/React/ReactAuthSimple/cors.js
+++ b/API/React/ReactAuthSimple/cors.js
@@ -8,13 +8,13 @@ http
     const reqUrl = url.parse(req.url);
     const domain = url.parse(proxyConfig.proxy).hostname;
     if (reqUrl.pathname.startsWith(proxyConfig.localApiPath)) {
-      
+
       const targetUrl = proxyConfig.proxy + reqUrl.pathname?.replace(proxyConfig.localApiPath, "") + (reqUrl.search || "");
 
       console.log("Incoming request -> " + req.url + " ===> " + reqUrl.pathname);
 
       const proxyReq = https.request(
-        targetUrl,
+        targetUrl, // CodeQL [SM04580] The newly generated target URL utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
         {
           method: req.method,
           headers: {

--- a/API/React/ReactAuthStateManagementAndUI/cors.js
+++ b/API/React/ReactAuthStateManagementAndUI/cors.js
@@ -8,13 +8,13 @@ http
     const reqUrl = url.parse(req.url);
     const domain = url.parse(proxyConfig.proxy).hostname;
     if (reqUrl.pathname.startsWith(proxyConfig.localApiPath)) {
-      
+
       const targetUrl = proxyConfig.proxy + reqUrl.pathname?.replace(proxyConfig.localApiPath, "") + (reqUrl.search || "");
 
       console.log("Incoming request -> " + req.url + " ===> " + reqUrl.pathname);
 
       const proxyReq = https.request(
-        targetUrl,
+        targetUrl, // CodeQL [SM04580] The newly generated target URL utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
         {
           method: req.method,
           headers: {

--- a/typescript/native-auth/angular-sample/cors.js
+++ b/typescript/native-auth/angular-sample/cors.js
@@ -38,7 +38,7 @@ http.createServer((req, res) => {
         console.log("Incoming request -> " + req.url + " ===> " + reqUrl.pathname);
 
         const proxyReq = https.request(
-            targetUrl,
+            targetUrl, // CodeQL [SM04580] The newly generated target URL utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
             {
                 method: req.method,
                 headers: {

--- a/typescript/native-auth/react-nextjs-sample/cors.js
+++ b/typescript/native-auth/react-nextjs-sample/cors.js
@@ -38,7 +38,7 @@ http.createServer((req, res) => {
         console.log("Incoming request -> " + req.url + " ===> " + reqUrl.pathname);
 
         const proxyReq = https.request(
-            targetUrl,
+            targetUrl, // CodeQL [SM04580] The newly generated target URL utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
             {
                 method: req.method,
                 headers: {


### PR DESCRIPTION
Suppress the CodeQL warnings since the relevant target URL only utilizes the configured proxy URL to resolve the CORS issue and will be used exclusively for demo purposes and run locally.
This suppression has been confirmed with the security team.